### PR TITLE
Change target to MKDocs & Update library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,3 +34,74 @@ jobs:
           key: v1-{{ .Branch }}-{{ epoch }}
           paths:
             - /caches/image.tar
+  release-docker-image:
+    docker:
+      - image: circleci/python:3.8.6
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Install awscli
+          command: sudo pip install awscli
+      - run:
+          name: Login ECR repository
+          command: eval $(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)
+      - run:
+          name: Docker builld
+          command: docker build . -t ${CIRCLE_SHA1}
+      - run:
+          name: Push with version tag
+          command: |
+            version=$(git describe --abbrev=7)
+
+            # タグが打たれたコミットではないならSNAPSHOTを後ろにつける
+            if [ -z ${CIRCLE_TAG} ]
+            then
+              version=${version}-SNAPSHOT
+            fi
+
+            # gitのstatusがcleanでなければdirtyを後ろにつける
+            if [ ! -z $(git status --porcelain) ]
+            then
+              version=${version}+dirty
+            fi
+
+            echo "Tag: ${version}"
+
+            docker tag ${CIRCLE_SHA1} ${ECR_ACCOUNT_URL}/jp.classmethod.aws.metropolis/techdoc-ja:${version}
+            docker push ${ECR_ACCOUNT_URL}/jp.classmethod.aws.metropolis/techdoc-ja:${version}
+      - run:
+          name: Push with branch name or "latest"
+          command: |
+            # タグ付き、かつ、masterブランチのHEAD場合はlatestタグ
+            # それ以外のタグ付き(サポートブランチ等)は何もしない。それ以外はブランチ名をベースにタグを付ける
+            if [ -n "${CIRCLE_TAG}" -a `git rev-parse HEAD` = `git rev-parse origin/master` ]
+            then
+              branch_tag=latest
+            elif [ -n "${CIRCLE_TAG}" ]; then
+              echo "Skip branch name taging."
+              exit 0;
+            else
+              branch_tag=$(echo $CIRCLE_BRANCH | sed -e 's/\//_/g')
+            fi
+
+            echo "Tag: ${branch_tag}"
+
+            docker tag ${CIRCLE_SHA1} ${ECR_ACCOUNT_URL}/jp.classmethod.aws.metropolis/techdoc-ja:${branch_tag}
+            docker push ${ECR_ACCOUNT_URL}/jp.classmethod.aws.metropolis/techdoc-ja:${branch_tag}
+
+workflows:
+  version: 2
+  all:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - release-docker-image:
+          context: pz-docker-release-context
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9.3.0
+FROM node:14.14.0-buster-slim
 
 LABEL maintainer "Daisuke Miyamoto <miyamoto.daisuke@classmethod.jp>"
 
@@ -6,96 +6,121 @@ LABEL maintainer "Daisuke Miyamoto <miyamoto.daisuke@classmethod.jp>"
 ###############################################################################
 ## setup
 
-ENV LANG ja_JP.UTF-8
-RUN echo "deb http://http.debian.net/debian jessie-backports main" >>/etc/apt/sources.list \
-  && apt-get clean \
+ENV DEBCONF_NOWARNINGS yes
+RUN apt-get clean \
   && apt-get update \
-  && apt-get install -y locales-all
-
+  && apt-get install -y locales \
+  && locale-gen ja_JP.UTF-8
+ENV LANG ja_JP.UTF-8
+ENV LANGUAGE ja_JP:ja
+ENV LC_ALL=ja_JP.UTF-8
+RUN localedef -f UTF-8 -i ja_JP ja_JP.utf8
 
 ###############################################################################
-# install Java (for PlantUML, RedPen)
+# install Java 8 (for PlantUML, RedPen)
 
-RUN apt-get install -y -qq -t jessie-backports openjdk-8-jdk \
-  && update-java-alternatives --set java-1.8.0-openjdk-amd64
-
+# 参考: https://qiita.com/PINTO/items/612718c0ce4f1def6c6e
+RUN mkdir -p /usr/share/man/man1 \
+  && apt-get -y -qq install \
+  apt-transport-https \
+  ca-certificates \
+  wget \
+  dirmngr \
+  gnupg \
+  software-properties-common \
+  && wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - \
+  && add-apt-repository 'deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ buster main' \
+  && apt-get -y -qq update \
+  && apt-get -y -qq install adoptopenjdk-8-hotspot\
+  && add-apt-repository --remove 'deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ buster main' \
+  && update-java-alternatives --jre-headless --jre --set adoptopenjdk-8-hotspot-amd64
 
 ###############################################################################
 # install AWS CLI (for deploy)
 
 RUN apt-get install -y -qq python3-pip \
-  && pip3 install awscli==1.14.11
+  && ln -s /usr/bin/python3 /usr/bin/python \
+  && python -m pip install -U pip \
+  && pip3 install awscli==1.18.218
 
+###############################################################################
+# install git
+
+RUN apt-get update \
+    && apt-get install -y git
+
+###############################################################################
+# install mkdocs
+
+RUN pip3 install mkdocs \
+  && pip3 install mkdocs-material \
+  && pip3 install mkpdfs-mkdocs \
+  && pip3 install plantuml-markdown \
+  && pip3 install fontawesome_markdown
+
+###############################################################################
+# install markdownlint
+
+RUN npm install -g markdownlint-cli@0.26.0
 
 ###############################################################################
 # install RedPen
 
-ENV REDPEN_VERSION 1.10.1
+ENV REDPEN_VERSION 1.10.4
 
 RUN wget -nv -O - https://github.com/redpen-cc/redpen/releases/download/redpen-${REDPEN_VERSION}/redpen-${REDPEN_VERSION}.tar.gz | tar zx -C /opt
 ENV PATH $PATH:/opt/redpen-distribution-${REDPEN_VERSION}/bin
-
 
 ###############################################################################
 # install textlint
 
 RUN npm install -g \
-    textlint@10.0.0 \
-    textlint-rule-no-todo@2.0.0 \
-    textlint-rule-no-start-duplicated-conjunction@1.1.4 \
-    textlint-rule-prh@5.0.1 \
+    textlint@11.8.2 \
+    textlint-rule-no-todo@2.0.1 \
+    textlint-rule-no-start-duplicated-conjunction@2.0.2 \
+    textlint-rule-prh@5.3.0 \
     textlint-rule-max-number-of-lines@1.0.3 \
     textlint-rule-max-comma@1.0.4 \
-    textlint-rule-no-exclamation-question-mark@1.0.2 \
-    textlint-rule-no-dead-link@4.1.0 \
+    textlint-rule-no-exclamation-question-mark@1.1.0 \
+    textlint-rule-no-dead-link@4.7.0 \
     textlint-rule-editorconfig@1.0.3 \
     textlint-rule-no-empty-section@1.1.0 \
     textlint-rule-date-weekday-mismatch@1.0.5 \
-    textlint-rule-terminology@1.1.24 \
-    textlint-rule-period-in-list-item@0.2.0 \
-    textlint-rule-no-nfd@1.0.1 \
+    textlint-rule-terminology@2.1.5 \
+    textlint-rule-period-in-list-item@0.3.2 \
+    textlint-rule-no-nfd@1.0.2 \
     textlint-rule-no-surrogate-pair@1.0.1 \
     textlint-rule-common-misspellings@1.0.1 \
-    textlint-rule-max-ten@2.0.3 \
+    textlint-rule-max-ten@2.0.4 \
     textlint-rule-max-kanji-continuous-len@1.1.1 \
     textlint-rule-spellcheck-tech-word@5.0.0 \
     textlint-rule-web-plus-db@1.1.5 \
-    textlint-rule-no-mix-dearu-desumasu@3.0.3 \
-    textlint-rule-no-doubled-joshi@3.5.1 \
-    textlint-rule-no-double-negative-ja@1.0.5 \
+    textlint-rule-no-mix-dearu-desumasu@4.0.1 \
+    textlint-rule-no-doubled-joshi@3.8.0 \
+    textlint-rule-no-double-negative-ja@1.0.6 \
     textlint-rule-no-hankaku-kana@1.0.2 \
-    textlint-rule-ja-no-weak-phrase@1.0.4 \
-    textlint-rule-ja-no-redundant-expression@1.0.3 \
-    textlint-rule-ja-no-abusage@1.2.1 \
+    textlint-rule-ja-no-weak-phrase@1.0.5 \
+    textlint-rule-ja-no-redundant-expression@3.0.2 \
+    textlint-rule-ja-no-abusage@2.0.1 \
     textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet@1.0.1 \
-    textlint-rule-sentence-length@1.1.3 \
-    textlint-rule-no-dropping-the-ra@1.1.2 \
-    textlint-rule-no-doubled-conjunctive-particle-ga@1.0.2 \
-    textlint-rule-no-doubled-conjunction@1.0.2 \
-    textlint-rule-ja-no-mixed-period@2.0.0 \
+    textlint-rule-sentence-length@2.2.0 \
+    textlint-rule-no-dropping-the-ra@2.0.0 \
+    textlint-rule-no-doubled-conjunctive-particle-ga@1.1.1 \
+    textlint-rule-no-doubled-conjunction@1.0.3 \
+    textlint-rule-ja-no-mixed-period@2.1.1 \
     textlint-rule-ja-yahoo-kousei@1.0.3 \
     textlint-rule-max-appearence-count-of-words@1.0.1 \
     textlint-rule-max-length-of-title@1.0.1 \
     textlint-rule-incremental-headers@0.2.0 \
-    textlint-rule-ja-unnatural-alphabet@1.3.0 \
+    textlint-rule-ja-unnatural-alphabet@2.0.1 \
     @textlint-ja/textlint-rule-no-insert-dropping-sa@1.0.1 \
-    textlint-rule-preset-ja-technical-writing@2.0.0 \
-    textlint-rule-preset-jtf-style@2.3.1 \
-    textlint-rule-preset-ja-spacing@2.0.1 \
-    textlint-rule-preset-japanese@2.0.0 \
-    textlint-filter-rule-whitelist@1.2.3 \
+    textlint-rule-preset-ja-technical-writing@4.0.1 \
+    textlint-rule-preset-jtf-style@2.3.6 \
+    textlint-rule-preset-ja-spacing@2.0.2 \
+    textlint-rule-preset-japanese@5.0.0 \
+    textlint-filter-rule-allowlist@2.0.1 \
     textlint-filter-rule-comments@1.2.2 \
-    textlint-filter-rule-node-types@1.0.1
-
-###############################################################################
-# install markdownlint
-
-RUN npm install -g markdownlint-cli@0.7.1
-
-###############################################################################
-# install gitbook
-
-RUN npm install -g gitbook-cli && gitbook fetch 3.2.2
+    textlint-filter-rule-node-types@1.1.0
 
 ###############################################################################
 # install Japanese font (for PDF)
@@ -116,3 +141,9 @@ ENV CALIBRE_INSTALLER_SOURCE_CODE_URL https://raw.githubusercontent.com/kovidgoy
 
 RUN wget -O - ${CALIBRE_INSTALLER_SOURCE_CODE_URL} | python -c "import sys; main=lambda:sys.stderr.write('Download failed\n'); exec(sys.stdin.read()); main(install_dir='/opt', isolated=True)"
 ENV PATH $PATH:/opt/calibre
+
+
+###############################################################################
+# clean up
+
+RUN apt-get clean && apt-get autoremove

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV LC_ALL=ja_JP.UTF-8
 RUN localedef -f UTF-8 -i ja_JP ja_JP.utf8
 
 ###############################################################################
-# install Java 8 (for PlantUML, RedPen)
+# install Java 11 (for PlantUML, RedPen)
 
 # 参考: https://qiita.com/PINTO/items/612718c0ce4f1def6c6e
 RUN mkdir -p /usr/share/man/man1 \
@@ -31,9 +31,9 @@ RUN mkdir -p /usr/share/man/man1 \
   && wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - \
   && add-apt-repository 'deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ buster main' \
   && apt-get -y -qq update \
-  && apt-get -y -qq install adoptopenjdk-8-hotspot\
+  && apt-get -y -qq install adoptopenjdk-11-hotspot\
   && add-apt-repository --remove 'deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ buster main' \
-  && update-java-alternatives --jre-headless --jre --set adoptopenjdk-8-hotspot-amd64
+  && update-java-alternatives --jre-headless --jre --set adoptopenjdk-11-hotspot-amd64
 
 ###############################################################################
 # install AWS CLI (for deploy)
@@ -55,8 +55,7 @@ RUN apt-get update \
 RUN pip3 install mkdocs \
   && pip3 install mkdocs-material \
   && pip3 install mkpdfs-mkdocs \
-  && pip3 install plantuml-markdown \
-  && pip3 install fontawesome_markdown
+  && pip3 install plantuml-markdown
 
 ###############################################################################
 # install markdownlint

--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@
 
 - Node.js v9.3.0
 - OpenJDK 1.8.0_131
-- RedPen 1.10.1
-- textlint v10.0.0
-- markdownlint-cli v0.7.1
-- GitBook 3.2.2
+- RedPen 1.10.4
+- textlint v11.8.1
+- markdownlint-cli v0.26.0
 - graphviz version 2.38.0 (20140413.2041)
-- Python/3.4.2
-- aws-cli 1.14.11
+- Python/3.8.6
+- aws-cli 1.18.218
 
 これらをインストールした [Docker イメージ](https://hub.docker.com/r/classmethod/techdoc-ja/)
 およびその[利用方法](usage.md)を、本プロジェクトの成果物とします。

--- a/test.sh
+++ b/test.sh
@@ -25,6 +25,6 @@ docker run -v $PWD:/src $dockerImage redpen -v &>/dev/null || (echo "redpen fail
 docker run -v $PWD:/src $dockerImage textlint -v &>/dev/null || (echo "textlint failed" && exit 1)
 docker run -v $PWD:/src $dockerImage markdownlint -V &>/dev/null || (echo "markdownlint failed" && exit 1)
 
-docker run -v $PWD:/src $dockerImage gitbook &>/dev/null || (echo "gitbook failed" && exit 1)
+#docker run -v $PWD:/src $dockerImage gitbook &>/dev/null || (echo "gitbook failed" && exit 1)
 docker run -v $PWD:/src $dockerImage ebook-convert --version &>/dev/null || (echo "ebook-convert failed" && exit 1)
 


### PR DESCRIPTION
# 概要

GitBook CLI の開発が止まり、一部のサービスで MKDocs を導入することになったため、
MKDocs ドキュメント構築用に内容を書き換え、古くなっていたライブラリも最新バージョンに更新した。

古いバージョンをタグ指定すれば既存GitBookドキュメントに影響なし（GitBookの最新バージョン: `1.0.1`）

# 内容

* MKDocs ドキュメントを生成できるように必要なライブラリのインストールを追記、GitBook 関連のインストールなどを削除 
* docker-image を push できるように config.yml を修正
* locale 設定などいくつかの警告に対応
* textlintなど各種ライブラリを最新バージョンに更新